### PR TITLE
fix(aria-expanded): use boolean value

### DIFF
--- a/src/typeahead.js
+++ b/src/typeahead.js
@@ -175,7 +175,7 @@ class TypeAhead extends React.Component {
           role="combobox"
           aria-owns={optionsId}
           aria-haspopup="listbox"
-          aria-expanded={numberOfOptions && this.state.shouldOptionsBeVisible}
+          aria-expanded={Boolean(numberOfOptions) && this.state.shouldOptionsBeVisible}
         >
           {Input}
         </div>

--- a/test/typeahead.test.js
+++ b/test/typeahead.test.js
@@ -201,4 +201,9 @@ describe('<Typeahead />', () => {
     MountedTypeaheadContainer.find('li').first().simulate('mouseDown');
     expect(onMouseDown.called).to.be.true;
   });
+
+  it('should have aria-expanded false when no results', () => {
+    const combobox = MountedTypeaheadContainer.find({role: 'combobox'});
+    expect(combobox.prop('aria-expanded')).to.be.false;
+  });
 });


### PR DESCRIPTION
**Problem(s):** 
The dropdown container has an ARIA attribute that does not conform to a valid value. 

**Impact:** 
Critical 

**WCAG Rule:** 
Name, Role, Value (4.1.2 A: Incomplete implementation of API https://www.w3.org/WAI/WCAG21/Techniques/failures/F15.html) 
For all user interface components (including but not limited to: form elements, links and components generated by scripts), the name and role can be programmatically determined; states, properties, and values that can be set by the user can be programmatically set; and notification of changes to these items is available to user agents, including assistive technologies. https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_overview#name-role-value  

**How to Fix:** 
Update the aria-expanded attribute so that it conforms to a valid value. When the search dropdown is not visible, aria-expanded should equal "false". When the search dropdown is visible, aria-expanded should equal "true". 

**Side note:** I couldn't get tests to run with `nyc` even after a bit of experimentation with node versions and `npm ci` etc. They pass fine if I remove that from test so ¯\\_(ツ)_/¯